### PR TITLE
Remove unnecessary Arc

### DIFF
--- a/app/src/server/middleware.rs
+++ b/app/src/server/middleware.rs
@@ -10,19 +10,19 @@ use iron::prelude::*;
 use persistent::Read;
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::sync::{Arc, Mutex, mpsc::Sender};
+use std::sync::{Mutex, mpsc::Sender};
 
 pub struct PirrigatorData {
 	database: Database,
 	zones: HashMap<String, Zone>,
-	tx: Arc<Mutex<Sender<Event>>>
+	tx: Mutex<Sender<Event>>,
 }
 
 impl PirrigatorData {
 	pub fn new(database: Database, zones: &Vec<Zone>, tx: Sender<Event>) -> PirrigatorData {
 		PirrigatorData {
 			database,
-			tx: Arc::new(Mutex::new(tx)),
+			tx: Mutex::new(tx),
 			zones: HashMap::from_iter(zones.iter().map(|z| (z.name.clone(), z.clone()) ))
 		}
 	}


### PR DESCRIPTION
Hi. I was only able to remove the `Arc` 😅.  The `Mutex` is required because `Sender` needs to be, not only`Send`, but also `Sync`. From what I can tell, this comes from the fact that `persistent::Read` needs to be `Clone` (https://docs.rs/plugin/0.2.6/plugin/trait.Pluggable.html#method.get), and to be `Clone`, it needs to be `Sync` (https://github.com/iron/persistent/blob/master/src/lib.rs#L122-L126). Nevertheless, the `Mutex` here doesn't seem so bad, since it's only used to hand out `Sender`s (if I understand correctly). After that, the `Sender`s can be used without contending on the `Mutex`. Again, thanks for the presentation!